### PR TITLE
rm dupe HAS_NETSNMP

### DIFF
--- a/plugins/plugin_utils/snmp_connection_base.py
+++ b/plugins/plugin_utils/snmp_connection_base.py
@@ -16,12 +16,8 @@ from ansible.utils.display import Display
 from .netsnmp_defs import SnmpConfiguration
 from .netsnmp_defs import SnmpResponse
 
-try:
-    from .netsnmp_instance import SnmpInstance
-
-    HAS_NETSNMP = True
-except ImportError:
-    HAS_NETSNMP = False
+from .netsnmp_instance import SnmpInstance
+from .netsnmp_instance import HAS_NETSNMP
 
 
 class SnmpConnectionBase(ConnectionBase):


### PR DESCRIPTION
The HAS_NETSNMP check has been moved into the netsnmp_instance where the import happens